### PR TITLE
ci: unblock cocogitto check (allow dockerfile type, scope to latest tag)

### DIFF
--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -37,5 +37,8 @@ jobs:
         uses: cocogitto/cocogitto-action@v3
         with:
           release: true
+          # Only check commits since the latest tag - the repo predates
+          # conventional commits and has legacy non-conventional history.
+          check-latest-tag-only: true
           git-user: 'cog-bot'
           git-user-email: 'cog-bot@users.noreply.github.com'

--- a/cog.toml
+++ b/cog.toml
@@ -13,6 +13,12 @@ post_bump_hooks = [
     "git push --tags",
 ]
 
+# `dockerfile:` commit type for Dockerfile-only changes (kept out of changelog).
+# Needed so `cog check` / `cog bump --auto` accept the existing `dockerfile:`
+# commit on master (the standard type would be `build:`).
+[commit_types]
+dockerfile = { omit_from_changelog = true }
+
 [changelog]
 path = "CHANGELOG.md"
 template = "remote"


### PR DESCRIPTION
## Problem

The `🔄 Auto Version Bump` workflow fails at the `cog check` step (latest failed run on `style: lint code`, commit `1171ec6`):

```
Error: Found 59 non compliant commits in 9000549..HEAD:
  'dockerfile: harden package symlink ...' -> Commit type `dockerfile` not allowed
  'bump: version 0.10.2 -> 0.11.0'        -> Commit type `bump` not allowed
  'update' / 'init' / 'Initial commit'    -> Missing commit type separator `:`
```

## Root cause

The repo migrated from commitizen to cocogitto. Two things make `cog check` fail:

1. `cocogitto-action@v3` defaults to `check: true` + `check-latest-tag-only: false`, so `cog check` scans the **entire history** and hits 58 legacy non-conventional commits that predate conventional commits (`update`, `init`, `bump: version X -> Y`, `Initial commit`, …). These have no valid `type:` separator, so they can't be salvaged by allowing a commit type.
2. `26771a3 dockerfile: harden package symlink with ln -sfnT` sits on master **after** the `0.11.0` tag, and `dockerfile` is not one of cocogitto's allowed commit types (the standard type for Dockerfile changes is `build:`). `cog bump --auto` uses the same parser, so it would also choke on this commit.

The rest of the release chain is already wired up and working: `cog.toml` has `pre_bump_hooks` (`uv lock`) and `post_bump_hooks` (`git push` / `git push --tags`) plus a package hook that bumps `pyproject.toml` via `uv version --package`; `package-release.yaml` builds + publishes to PyPI and creates the GitHub Release on the semver tag push; `docker-release.yaml` builds the image on `release: published`. The `cog check` failure is the only thing blocking it.

## Fix

- **`cog.toml`** — add `[commit_types] dockerfile = { omit_from_changelog = true }` so `cog check` / `cog bump --auto` accept the existing `dockerfile:` commit.
- **`version-bump.yaml`** — set `check-latest-tag-only: true` so `cog check --from-latest-tag` only scans `0.11.0..HEAD`, skipping the pre-conventional history.

### Why allow `dockerfile` instead of rewording the commit?

The `dockerfile:` commit is already pushed to master. Rewording it to `build:` would be the "cleaner" conventional-commits fix, but it requires force-pushing master (rewriting the 14 unreleased commits' SHAs, and further diverging the local `feat/airflow3-uv-workspace` rebased copy). Adding the type is non-destructive. If you'd rather reword instead, say so and I'll switch.

## On merge

Merging this runs the full release chain: `cog bump --auto` cuts the next version (cocogitto's `0.y.z` rules apply), pushes the tag → `package-release.yaml` builds + publishes + creates the GitHub Release → `docker-release.yaml` builds the Airflow 3 image. (Local pre-commit `yamlfmt`, workflow validation, and workflow lint all pass on this change.)

⚠️ Sequencing with shawndeng-homelab/homelab-cluster#3: the cluster Airflow 3 migration pins `images.airflow.tag: 0.11.0` (an Airflow 2 image). Merge **this** PR first so a real Airflow 3 image exists; Flux's `ImagePolicy` (`>=0.2.1`) will then auto-rewrite the cluster's tag to the new version. Merging the cluster PR before an Airflow 3 image exists leaves the cluster running an Airflow 2 image under an Airflow 3 chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
