### PR TITLE
fix: add cocogitto changelog separator so cog bump can update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changelog
+All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
+
+- - -
 ## 0.11.0 (2026-01-24)
 
 ### Feat


### PR DESCRIPTION
cog bump --auto failed with "cannot find default separator '- - -' in CHANGELOG.md" because the existing CHANGELOG.md was commitizen-format (`## X.Y.Z (date)` / `### Feat`) with no cocogitto header or `- - -` separator that cog looks for when prepending a new release.

Prepend the cocogitto changelog header + `- - -` separator above the existing entries so cocogitto's update path finds the separator and inserts new versions below it. Old 0.5.4-0.11.0 entries are preserved (commitizen format) below the separator.