### PR TITLE
fix: add release build pypi auth

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      UV_INDEX_HOMELAB_USERNAME: ${{ secrets.PYPI_SERVER_USERNAME }}
+      UV_INDEX_HOMELAB_PASSWORD: ${{ secrets.PYPI_SERVER_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This is a `uv` workspace. The main package lives in `packages/homelab-airflow-dags/` and exposes Airflow code under `src/homelab_airflow_dags/`.
+
+- `src/homelab_airflow_dags/dags/`: DAG definitions, such as `ibkr_account_snapshot.py`
+- `src/homelab_airflow_dags/common_tasks/`: shared task helpers and operators
+- `src/homelab_airflow_dags/config.py`, `constants.py`: runtime config and shared values
+- `tests/`: pytest-based tests for the package
+- `docs/`: MkDocs documentation source
+- `docker/`: local Airflow stack and container files
+
+Keep new DAGs and helpers inside the package source tree; keep tests alongside the package under `tests/`.
+
+## Build, Test, and Development Commands
+
+Use `just` for day-to-day work:
+
+- `just init`: install workspace dependencies and pre-commit hooks
+- `just lint`: run Ruff fix, format, and lint checks
+- `just test`: run the test suite for the default Python version
+- `just test-all`: run tests across the configured Python version range
+- `just docs`: serve the documentation locally
+- `just docs-build`: build the static docs site
+- `just podman-compose-up` / `just podman-compose-down`: start or stop the local Airflow stack
+
+If `just` is not installed, the README uses `uvx --from rust-just just ...`.
+
+## Coding Style & Naming Conventions
+
+Target Python 3.12. Follow the existing Ruff-driven style: standard formatting, sorted imports, and no extra lint suppressions unless necessary. Use `snake_case` for modules, functions, and variables; use descriptive DAG and task names. Keep helper modules small and purpose-driven.
+
+## Testing Guidelines
+
+Tests use `pytest` with coverage enabled through the `just` recipes. Name test files `test_*.py` and keep fixtures in `conftest.py` when they are shared. Add or update tests whenever DAG behavior, config parsing, or shared helpers change.
+
+## Commit & Pull Request Guidelines
+
+Recent commits use short conventional prefixes such as `fix:`, `refactor:`, `style:`, and `chore(version):`. Keep commit subjects imperative and scoped.
+
+Pull requests should include:
+
+- a short summary of the change and why it exists
+- validation steps run locally, such as `just lint` and `just test`
+- linked issues or follow-up tasks when relevant
+- screenshots only for doc or UI-visible changes
+
+## Security & Configuration Tips
+
+This project resolves runtime configuration through Consul-backed settings. Do not commit secrets, tokens, or environment-specific values; prefer local environment variables or documented config files.


### PR DESCRIPTION
This pull request introduces a new contributor guide and improves the package release workflow by securely passing credentials as environment variables. The main focus is on providing clear guidelines for repository structure, development practices, and security, while enhancing the automation for package publishing.

Repository documentation:

* Added a comprehensive contributor and project guidelines section to `AGENTS.md`, detailing project structure, development commands, coding standards, testing, commit/PR practices, and security tips.

CI/CD and security improvements:

* Updated `.github/workflows/package-release.yaml` to pass PyPI credentials (`PYPI_SERVER_USERNAME` and `PYPI_SERVER_PASSWORD`) as environment variables for secure package publishing.