### PR TITLE
fix: register bark package with cocogitto

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -34,3 +34,11 @@ changelog_path = "packages/homelab-airflow-dags/CHANGELOG.md"
 pre_bump_hooks = [
     "uv version --package homelab-airflow-dags {{version}}",
 ]
+
+[packages.homelab-airflow-bark]
+path = "packages/homelab-airflow-bark"
+public_api = true
+changelog_path = "packages/homelab-airflow-bark/CHANGELOG.md"
+pre_bump_hooks = [
+    "uv version --package homelab-airflow-bark {{version}}",
+]

--- a/packages/homelab-airflow-bark/CHANGELOG.md
+++ b/packages/homelab-airflow-bark/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.


### PR DESCRIPTION
This pull request adds configuration and changelog setup for the new `homelab-airflow-bark` package. The main changes are as follows:

**New package configuration:**

* Added a new section for `homelab-airflow-bark` in `cog.toml`, specifying its path, enabling its public API, linking its changelog, and defining a pre-bump hook for version management.

**Changelog initialization:**

* Created an initial `CHANGELOG.md` file for `homelab-airflow-bark` with the standard header.