### PR TITLE
Fix/cog bark changelog

### DIFF
--- a/packages/homelab-airflow-bark/CHANGELOG.md
+++ b/packages/homelab-airflow-bark/CHANGELOG.md
@@ -1,3 +1,0 @@
-# Changelog
-
-All notable changes to this package will be documented in this file.


### PR DESCRIPTION
This pull request removes the `CHANGELOG.md` file from the `packages/homelab-airflow-bark` package. This means the changelog will no longer be available in this location.