### PR TITLE
fix: make youtube dataset event metadata hashable

### DIFF
--- a/packages/homelab-airflow-providers-youtube/src/homelab_airflow_providers_youtube/datasets.py
+++ b/packages/homelab-airflow-providers-youtube/src/homelab_airflow_providers_youtube/datasets.py
@@ -45,7 +45,9 @@ def channel_event_extra(
     """Return bounded event metadata for one channel discovery batch."""
     return {
         "video_count": len(videos),
-        "video_ids": [video.video_id for video in videos[:50]],
+        # Airflow deduplicates Dataset events with ``frozenset(extra.items())``,
+        # so every top-level value must be hashable before JSON serialization.
+        "video_ids": tuple(video.video_id for video in videos[:50]),
         "published_after": published_after.isoformat() if published_after else None,
         "published_before": published_before.isoformat() if published_before else None,
     }

--- a/packages/homelab-airflow-providers-youtube/tests/test_operator.py
+++ b/packages/homelab-airflow-providers-youtube/tests/test_operator.py
@@ -27,7 +27,8 @@ def test_operator_returns_json_and_emits_bounded_dataset_event(mocker) -> None:
     assert result[0]["video_id"] == "video-1"
     assert result[0]["published_at"] == "2026-08-18T01:00:00Z"
     assert operator.outlets[0].uri == "youtube://channel/UCabc/uploads"
-    assert events[operator.outlet].extra["video_ids"] == ["video-1"]
+    assert events[operator.outlet].extra["video_ids"] == ("video-1",)
+    assert frozenset(events[operator.outlet].extra.items())
 
 
 def test_operator_supports_dataset_alias_for_templated_channel() -> None:


### PR DESCRIPTION
This pull request updates the way `video_ids` are handled in the `channel_event_extra` function to ensure compatibility with Airflow's dataset event deduplication logic. The main change is to use a tuple instead of a list for `video_ids`, since Airflow requires all top-level values in the event metadata to be hashable.

**Compatibility improvements with Airflow event deduplication:**

* Changed `video_ids` in the `channel_event_extra` function from a list to a tuple to ensure all top-level values are hashable as required by Airflow’s deduplication mechanism. (`packages/homelab-airflow-providers-youtube/src/homelab_airflow_providers_youtube/datasets.py`)
* Updated the related test to check for a tuple instead of a list for `video_ids`, and added an explicit check that the event metadata is hashable via `frozenset`. (`packages/homelab-airflow-providers-youtube/tests/test_operator.py`)